### PR TITLE
Feature/83 empty shop search produces error

### DIFF
--- a/frontend/src/app/shop-search-page/shop-search-page.component.html
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.html
@@ -2,7 +2,7 @@
   <mat-form-field style="width: 100%;">
     <mat-label>Suche</mat-label>
     <input matInput placeholder="Dein Lieblingsgeschäft..." [(ngModel)]="searchBusiness" (keyup.enter)="performSearch()">
-    <mat-icon matSuffix>search</mat-icon>
+    <a (click)="performSearch()" matSuffix><mat-icon >search</mat-icon></a>
   </mat-form-field>
 </div>
 <div style="width: 100%; margin-top: 25px;">

--- a/frontend/src/app/shop-search-page/shop-search-page.component.ts
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.ts
@@ -79,7 +79,8 @@ export class ShopSearchPageComponent implements OnInit {
   }
 
   private doSearchRequest() {
-    this.client.get<ShopListDto>('/api/shop/search?location=' + this.location + '&query=' + this.searchBusiness).subscribe(
+    let urlEscapedSearchInput = encodeURIComponent(this.searchBusiness);
+    this.client.get<ShopListDto>('/api/shop/search?location=' + this.location + '&query=' + urlEscapedSearchInput).subscribe(
       response => {
         this.dataSource = new MatTableDataSource<ShopListEntryDto>();
         if (response.shops.length > 0) {

--- a/frontend/src/app/shop-search-page/shop-search-page.component.ts
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.ts
@@ -4,7 +4,7 @@ import {MatSort} from '@angular/material/sort';
 import {ActivatedRoute, Router} from '@angular/router';
 import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
 import {ShopDetailDto, ShopListDto, ShopListEntryDto} from '../data/client';
-import {NotificationsService} from "angular2-notifications";
+import {NotificationsService} from 'angular2-notifications';
 import ContactTypesEnum = ShopDetailDto.ContactTypesEnum;
 
 @Component({
@@ -20,7 +20,10 @@ export class ShopSearchPageComponent implements OnInit {
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   displayedColumns: string[] = ['name', 'distance', 'supportedContactTypes'];
 
-  constructor(private route: ActivatedRoute, private router: Router, private client: HttpClient, private notificationsService: NotificationsService) {
+  constructor(private route: ActivatedRoute,
+              private router: Router,
+              private client: HttpClient,
+              private notificationsService: NotificationsService) {
 
     this.dataUpdate = this.dataUpdate.bind(this);
     this.handleParamsUpdate = this.handleParamsUpdate.bind(this);
@@ -56,7 +59,7 @@ export class ShopSearchPageComponent implements OnInit {
   }
 
   performSearch() {
-    if(!this.searchBusiness || this.searchBusiness.trim().length == 0) {
+    if (!this.searchBusiness || this.searchBusiness.trim().length === 0) {
       this.findAllShopsNearby();
     } else {
       this.findShopsBySearchQuery(this.searchBusiness);
@@ -65,9 +68,9 @@ export class ShopSearchPageComponent implements OnInit {
 
   private findAllShopsNearby(): void {
     const headers = new HttpHeaders().set('Content-Type', 'application/json; charset=utf-8');
-    const params = new HttpParams().append("location",  this.location);
+    const params = new HttpParams().append('location',  this.location);
 
-    this.client.get<ShopListDto>('/api/shop/nearby', {headers: headers, params: params}).subscribe(
+    this.client.get<ShopListDto>('/api/shop/nearby', {headers, params}).subscribe(
       response => {
         if (response.shops.length > 0) {
           this.dataSource = new MatTableDataSource<ShopListEntryDto>(response.shops);
@@ -85,9 +88,9 @@ export class ShopSearchPageComponent implements OnInit {
   }
 
   private findShopsBySearchQuery(query: string): void {
-    const params = new HttpParams().append("location",  this.location).append("query", query);
+    const params = new HttpParams().append('location',  this.location).append('query', query);
 
-    this.client.get<ShopListDto>('/api/shop/search',  {params: params}).subscribe(
+    this.client.get<ShopListDto>('/api/shop/search',  {params}).subscribe(
       response => {
         this.dataSource = new MatTableDataSource<ShopListEntryDto>();
         if (response.shops.length > 0) {

--- a/frontend/src/app/shop-search-page/shop-search-page.component.ts
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.ts
@@ -71,6 +71,14 @@ export class ShopSearchPageComponent implements OnInit {
   }
 
   performSearch() {
+    if(!this.searchBusiness || this.searchBusiness.trim().length == 0) {
+      this.notificationsService.info("Ungültige Suche", "Die Sucheingabe darf nicht leer sein.")
+    } else {
+      this.doSearchRequest();
+    }
+  }
+
+  private doSearchRequest() {
     this.client.get<ShopListDto>('/api/shop/search?location=' + this.location + '&query=' + this.searchBusiness).subscribe(
       response => {
         this.dataSource = new MatTableDataSource<ShopListEntryDto>();


### PR DESCRIPTION
Fixes #83 - empty search field is now the same like initial load (load all shops)

Additional improvements:
- Made icon clickable
- Escape input for URL parameters