### PR TITLE
#39 Store zipCode in localStorage and use it to pre-fill the landing …

### DIFF
--- a/frontend/src/app/landing-page/landing-page.component.html
+++ b/frontend/src/app/landing-page/landing-page.component.html
@@ -24,7 +24,7 @@
       </mat-autocomplete>
     </mat-form-field>
 
-    <button class="form-item" type="submit" [disabled]="!form.valid"
+    <button class="form-item" type="submit" [disabled]="startDisabled"
             (click)="start()"
             mat-raised-button
             color="primary">

--- a/frontend/src/app/landing-page/landing-page.component.html
+++ b/frontend/src/app/landing-page/landing-page.component.html
@@ -24,9 +24,8 @@
       </mat-autocomplete>
     </mat-form-field>
 
-    <button class="form-item" type="submit" [disabled]="!form.valid || this.suggestions.length < 1"
-            [routerLink]="['/shops']"
-            [queryParams]="{ location: this.form.controls.zipCode.value}"
+    <button class="form-item" type="submit" [disabled]="!form.valid"
+            (click)="start()"
             mat-raised-button
             color="primary">
       Los geht's!

--- a/frontend/src/app/landing-page/landing-page.component.spec.ts
+++ b/frontend/src/app/landing-page/landing-page.component.spec.ts
@@ -1,25 +1,85 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 
-import { LandingPageComponent } from './landing-page.component';
+import {LandingPageComponent} from './landing-page.component';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {LocationControllerService} from '../data/client';
+import {ZipCodeCacheService} from './zip-code-cache.service';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {MatAutocompleteModule} from '@angular/material/autocomplete';
 
 describe('LandingPageComponent', () => {
   let component: LandingPageComponent;
   let fixture: ComponentFixture<LandingPageComponent>;
+  let httpMock;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LandingPageComponent ]
+      declarations: [ LandingPageComponent ],
+      imports: [ReactiveFormsModule, FormsModule, HttpClientTestingModule, RouterTestingModule, MatAutocompleteModule],
+      providers: [ LocationControllerService, ZipCodeCacheService]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
+    // clear zip code cache
+    new ZipCodeCacheService().setZipCode('');
+
     fixture = TestBed.createComponent(LandingPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should disable start initially', () => {
+    new ZipCodeCacheService().setZipCode('');
+
+    component.ngOnInit();
+
+    expect(component.startDisabled).toBeTrue();
+  });
+
+  it('should enable start if there is a valid cached zipCode', () => {
+    new ZipCodeCacheService().setZipCode('12345');
+
+    component.ngOnInit();
+
+    expect(component.startDisabled).toBeFalse();
+  });
+
+  it('should enable start on input with location hits', fakeAsync(() => {
+    new ZipCodeCacheService().setZipCode('');
+    component.ngOnInit();
+    expect(component.startDisabled).toBeTrue();
+
+    component.form.controls.zipCode.setValue('83024');
+    tick(300);
+
+    const req = httpMock.expectOne('/api/location/suggestion?zipCode=83024');
+    req.flush( {suggestions: [{countryCode: 'DE', zipCode: '83024', placeName: 'Rosenheim'}]});
+
+    expect(component.startDisabled).toBeFalse();
+  }));
+
+
+  it('should disable start on input without location hits', fakeAsync(() => {
+    new ZipCodeCacheService().setZipCode('');
+    component.ngOnInit();
+    expect(component.startDisabled).toBeTrue();
+
+    component.form.controls.zipCode.setValue('83021');
+    tick(200);
+
+    const req = httpMock.expectOne('/api/location/suggestion?zipCode=83021');
+    req.flush({suggestions: []});
+
+    expect(component.startDisabled).toBeTrue();
+  }));
+
 });

--- a/frontend/src/app/landing-page/landing-page.component.ts
+++ b/frontend/src/app/landing-page/landing-page.component.ts
@@ -13,7 +13,7 @@ import {ZipCodeCacheService} from './zip-code-cache.service';
 })
 export class LandingPageComponent implements OnInit {
   location: string;
-  zipCode: string;
+  private zipCodeInitialValue: string;
   suggestions: LocationSuggestionDto[] = [];
   form: FormGroup;
 
@@ -25,9 +25,11 @@ export class LandingPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.zipCodeInitialValue = this.zipCodeCacheService.getZipCode();
+
     this.form = this.formBuilder.group({
       // pre-fill with value from cache (if present)
-      zipCode: [this.zipCodeCacheService.getZipCode(), [Validators.required, Validators.pattern(new RegExp(/^\d{5}$/))]]
+      zipCode: [this.zipCodeInitialValue, [Validators.required, Validators.pattern(new RegExp(/^\d{5}$/))]]
     });
 
     // clear completion if no user input
@@ -49,8 +51,36 @@ export class LandingPageComponent implements OnInit {
         })).subscribe(suggestions => this.suggestions = suggestions);
   }
 
+  public get startDisabled(): boolean {
+    return !this.startEnabled;
+  }
+
+  private get startEnabled(): boolean {
+    // form has to be valid (of course), if it is:
+    // - we allow to click start if the value was unchanged (this way the user can research fast)
+    //    or
+    // - if the changed zip code has hits
+    return this.form.valid && this.inputUnchangedOrHasSuggestionHits;
+  }
+
+  private get inputUnchangedOrHasSuggestionHits(): boolean {
+    return this.inputUnchanged || this.hasSuggestionHits;
+  }
+
+  private get inputUnchanged(): boolean {
+    return this.zipCodeInitialValue === this.zipCodeFromInput;
+  }
+
+  private get hasSuggestionHits(): boolean {
+    return this.suggestions.length > 0;
+  }
+
+  private get zipCodeFromInput(): string {
+    return this.form.controls.zipCode.value;
+  }
+
   public start(): void {
-    const locationFromInput = this.form.controls.zipCode.value;
+    const locationFromInput = this.zipCodeFromInput;
 
     // cache the zipCode for later
     this.zipCodeCacheService.setZipCode(locationFromInput);

--- a/frontend/src/app/landing-page/zip-code-cache.service.ts
+++ b/frontend/src/app/landing-page/zip-code-cache.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Simple caching service that stores the ZIP code in local storage
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ZipCodeCacheService {
+
+  private static readonly KEY = 'zipCode';
+
+  /**
+   * Set the zip code (and update it)
+   *
+   * @param zipCode zipCode that should be stored
+   */
+  public setZipCode(zipCode: string) {
+    localStorage.setItem(ZipCodeCacheService.KEY, zipCode);
+  }
+
+  /**
+   * Returns the last zip code or null if none is present
+   */
+  public getZipCode(): string {
+    return localStorage.getItem(ZipCodeCacheService.KEY);
+  }
+}


### PR DESCRIPTION
I use localStorage to save the last used zipCode. This zipCode is used the next time the user visits the landing page.

I had to remove '|| this.suggestions.length < 1' from the disable button logic, but I couldn't find any errors in my test. 
