### PR TITLE
Added E2E tests using Selenium and Geb.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,7 +33,6 @@ repositories {
 
 ext {
     drivers = ["firefox", "chrome", "chromeHeadless"]
-    baseUrl = "http://localhost:4200"
 
     ext {
         gebVersion = '3.4'
@@ -169,7 +168,7 @@ drivers.each { driver ->
 
         outputs.upToDateWhen { false }
 
-        systemProperty "geb.build.baseUrl", "$baseUrl"
+        systemProperty "geb.build.baseUrl", System.getProperty("baseUrl", "http://localhost:4200")
         systemProperty "geb.build.reportsDir", reporting.file("geb/$name")
         systemProperty "geb.env", driver
     }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,9 +4,13 @@ plugins {
     id 'java'
     id 'groovy'
     id 'jacoco'
+    id 'idea'
     id "org.sonarqube" version "2.8"
     // Writes git.properties with commit hash, etc.
     id "com.gorylenko.gradle-git-properties" version "2.2.2"
+
+    id "com.github.erdi.webdriver-binaries" version "2.2"
+    id "com.github.erdi.idea-base" version "2.2"
 }
 
 group = 'de.qaware.mercury'
@@ -18,10 +22,25 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    e2eTestCompile.extendsFrom testImplementation
+    e2eTestRuntime.extendsFrom testRuntime
 }
 
 repositories {
     mavenCentral()
+}
+
+ext {
+    drivers = ["firefox", "chrome", "chromeHeadless"]
+    baseUrl = "http://localhost:4200"
+
+    ext {
+        gebVersion = '3.4'
+        seleniumVersion = '3.14.0'
+        chromeDriverVersion = '79.0.3945.36'
+        geckoDriverVersion = '0.26.0'
+    }
 }
 
 dependencies {
@@ -66,6 +85,10 @@ dependencies {
 
     testRuntimeOnly "net.bytebuddy:byte-buddy:1.9.3"
     testRuntimeOnly "org.objenesis:objenesis:2.6"
+
+    e2eTestCompile "org.gebish:geb-spock:$gebVersion"
+    e2eTestCompile "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion"
+    e2eTestCompile "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
 }
 
 test {
@@ -97,3 +120,57 @@ sonarqube {
 
 // have some fun ./gradlew kick ass
 task kick(dependsOn: clean) {}
+
+sourceSets {
+    e2eTest {
+        groovy {
+            compileClasspath += sourceSets.main.output + configurations.e2eTestCompile
+            runtimeClasspath += output + compileClasspath + configurations.e2eTestRuntime
+            srcDir file('src/e2e/groovy')
+        }
+        resources.srcDir file('src/e2e/resources')
+    }
+}
+
+idea {
+    module {
+        testSourceDirs += sourceSets.e2eTest.groovy.srcDirs
+        testResourceDirs += sourceSets.e2eTest.resources.srcDirs
+        scopes.TEST.plus += [ configurations.e2eTestCompile, configurations.testCompile ]
+    }
+}
+
+webdriverBinaries {
+    chromedriver {
+        version = chromeDriverVersion
+        fallbackTo32Bit = true
+    }
+    geckodriver {
+        version = geckoDriverVersion
+    }
+}
+
+drivers.each { driver ->
+    task "${driver}Test"(type: Test) {
+        group JavaBasePlugin.VERIFICATION_GROUP
+
+        useJUnitPlatform()
+
+        testClassesDirs = sourceSets.e2eTest.output
+        classpath = sourceSets.e2eTest.runtimeClasspath
+
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
+
+        reports {
+            html.enabled = true
+        }
+
+        outputs.upToDateWhen { false }
+
+        systemProperty "geb.build.baseUrl", "$baseUrl"
+        systemProperty "geb.build.reportsDir", reporting.file("geb/$name")
+        systemProperty "geb.env", driver
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/FooterModule.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/FooterModule.groovy
@@ -1,0 +1,28 @@
+package de.qaware.mercury.e2e
+
+import geb.Module
+
+class FooterModule extends Module {
+    static content = {
+        login { $("div.app-footer a", 0) }
+        register { $("div.app-footer a", 1) }
+        imprint { $("div.app-footer a", 2) }
+        privacy { $("div.app-footer a", 3) }
+    }
+
+    void login() {
+        login.click(LoginPage)
+    }
+
+    void register() {
+        register.click()
+    }
+
+    void imprint() {
+        imprint.click(ImprintPage)
+    }
+
+    void privacy() {
+        privacy.click(PrivacyPage)
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/ImprintPage.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/ImprintPage.groovy
@@ -1,0 +1,15 @@
+package de.qaware.mercury.e2e
+
+import geb.Page
+
+class ImprintPage extends Page {
+
+    static url = "/#/imprint"
+
+    static at = { browser.pageUrl.endsWith('/#/imprint') }
+
+    static content = {
+        header { $("h1") }
+        footer { module(FooterModule) }
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/LoginPage.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/LoginPage.groovy
@@ -1,0 +1,26 @@
+package de.qaware.mercury.e2e
+
+import geb.Page
+import geb.module.FormElement
+import geb.module.PasswordInput
+import geb.module.TextInput
+
+class LoginPage extends Page {
+
+    static url = "/#/login"
+
+    static at = { browser.pageUrl.endsWith('/#/login') }
+
+    static content = {
+        header { $("h2") }
+        email { $("input", type: 'text', formcontrolname: 'email').module(TextInput) }
+        password { $("input", type: 'password', formcontrolname: 'password').module(PasswordInput) }
+        loginButton { $("button", 0, type: 'submit').module(FormElement) }
+        error { $('p', class: 'error') }
+        footer { module(FooterModule) }
+    }
+
+    void login() {
+        loginButton.click()
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/LoginSpec.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/LoginSpec.groovy
@@ -1,0 +1,46 @@
+package de.qaware.mercury.e2e
+
+import geb.spock.GebSpec
+import spock.lang.Stepwise
+import spock.lang.Unroll
+
+@Stepwise
+class LoginSpec extends GebSpec {
+
+    def "Login button is disabled on fresh login page"() {
+        given:
+        to LoginPage
+
+        expect:
+        at LoginPage
+        loginButton.isDisabled()
+    }
+
+    @Unroll
+    def "Check disabled login button for #mail"() {
+        given:
+        password.text = pwd
+        email.text = mail
+
+        expect:
+        loginButton.isDisabled()
+
+        where:
+        mail                  | pwd
+        "test@lokaler.kaufen" | ""
+        "test"                | "holy"
+        "test@"               | "secret"
+        "test@domain."        | ""
+    }
+
+    def "We can not login with unknown user"() {
+        when:
+        email.text = 'test@lokaler.kaufen'
+        password.text = '1qay2wsx'
+        login()
+
+        then:
+        loginButton.isEnabled()
+        waitFor { error }.text().startsWith('Sorry')
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/NavigationSpec.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/NavigationSpec.groovy
@@ -1,0 +1,44 @@
+package de.qaware.mercury.e2e
+
+import geb.spock.GebSpec
+import spock.lang.Stepwise
+
+@Stepwise
+class NavigationSpec extends GebSpec {
+
+    def "Can open Mercury start page"() {
+        when:
+        to StartPage
+
+        then:
+        at StartPage
+        searchButton.isDisabled()
+    }
+
+    def "We can navigate to Imprint page"() {
+        when:
+        footer.imprint()
+
+        then:
+        at ImprintPage
+        header.text() == 'Impressum'
+    }
+
+    def "We can navigate to Privacy page"() {
+        when:
+        footer.privacy()
+
+        then:
+        at PrivacyPage
+        header.text() == 'Privacy'
+    }
+
+    def "We can navigate to Login page"() {
+        when:
+        footer.login()
+
+        then:
+        at LoginPage
+        header.text().startsWith('Login')
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/PrivacyPage.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/PrivacyPage.groovy
@@ -1,0 +1,14 @@
+package de.qaware.mercury.e2e
+
+import geb.Page
+
+class PrivacyPage extends Page {
+    static url = "/#/privacy"
+
+    static at = { browser.pageUrl.endsWith('/#/privacy') }
+
+    static content = {
+        header { $("h1") }
+        footer { module(FooterModule) }
+    }
+}

--- a/backend/src/e2e/groovy/de/qaware/mercury/e2e/StartPage.groovy
+++ b/backend/src/e2e/groovy/de/qaware/mercury/e2e/StartPage.groovy
@@ -1,0 +1,18 @@
+package de.qaware.mercury.e2e
+
+import geb.Page
+import geb.module.FormElement
+import geb.module.TextInput
+
+class StartPage extends Page {
+
+    static url = "/#/"
+
+    static at = { title.startsWith('lokaler.kaufen') }
+
+    static content = {
+        postcode { $("input", 0, type: 'text').module(TextInput) }
+        searchButton { $("button", 0, type: 'submit').module(FormElement) }
+        footer { module(FooterModule) }
+    }
+}

--- a/backend/src/e2e/resources/GebConfig.groovy
+++ b/backend/src/e2e/resources/GebConfig.groovy
@@ -1,0 +1,32 @@
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.firefox.FirefoxDriver
+
+waiting {
+    timeout = 5
+}
+
+environments {
+    // run via “./gradlew chromeTest”
+    chrome {
+        driver = { new ChromeDriver() }
+    }
+
+    // run via “./gradlew chromeHeadlessTest”
+    chromeHeadless {
+        driver = {
+            ChromeOptions o = new ChromeOptions()
+            o.addArguments('headless')
+            new ChromeDriver(o)
+        }
+    }
+
+    // run via “./gradlew firefoxTest”
+    firefox {
+        atCheckWaiting = 1
+        driver = { new FirefoxDriver() }
+    }
+}
+
+// specify base URL via -Dgeb.build.baseUrl=http://localhost:4200
+//


### PR DESCRIPTION
Added E2E UI test for basic navigation and login behaviour using Geb and Selenium.
Tests can be executed against fully running system locally and against the test system.
Browsers: Firefox, Chrome and Chrome Headless.

```bash
# targets for local environment
$ ./gradlew chromeHeadlessTest
$ ./gradlew chromeTest
$ ./gradlew firefoxTest

# run against the test system
$ ./gradlew chromeHeadlessTest -DbaseUrl=https://test.lokaler.kaufen
```
